### PR TITLE
Fix ground and gap rendering offsets in game canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,13 +380,13 @@ function update(){
 function drawGround(){
   // cielo ya está por css; suelo
   ctx.fillStyle='#7ec850';
-  ctx.fillRect(0,GROUND+18,W,H-GROUND);
+  ctx.fillRect(0,GROUND,W,H-GROUND);
   ctx.fillStyle='#caa15a';
-  ctx.fillRect(0,GROUND+34,W,H);
+  ctx.fillRect(0,GROUND+16,W,H);
   // hoyos
   ctx.fillStyle='#bfeaff';
   for(const g of level.gaps){
-    ctx.fillRect(g.x, GROUND+18, g.w, H);
+    ctx.fillRect(g.x, GROUND, g.w, H);
   }
   // nubes
   ctx.fillStyle='rgba(255,255,255,.85)';


### PR DESCRIPTION
## Summary
Adjusted the vertical positioning of ground layers and gap elements in the game canvas to correct visual alignment issues.

## Key Changes
- Removed the +18 pixel offset from the main ground layer (`fillRect` call), aligning it directly to the `GROUND` constant
- Adjusted the sand/dirt layer offset from +34 to +16 pixels relative to `GROUND`
- Removed the +18 pixel offset from gap/hole rendering to align them with the corrected ground position

## Implementation Details
These changes ensure that the ground layers and gaps are rendered at consistent vertical positions. The adjustments appear to correct a misalignment where the ground visual elements were offset too far down the canvas, likely causing gaps between the sky and ground or visual inconsistencies in the game's terrain rendering.

https://claude.ai/code/session_01SkFueFRX4YWCE22caZthpH