### PR TITLE
Add CLAUDE.md documentation for AI-assisted development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a static single-file browser game called **"El Rescate de Manchitas"** — a 20-level 2D platformer written entirely in vanilla HTML/CSS/JavaScript with no build tools, dependencies, or framework.
+
+## Running the Project
+
+Open `index.html` directly in a browser. There is no server, build step, or package manager involved.
+
+## Architecture
+
+Everything lives in `index.html`:
+
+- **CSS** (lines 7–107): Layout for a faux "pink notebook computer" device frame, canvas stage, and on-screen control buttons.
+- **Game constants** (lines 199–230): `LEVELS` array defines all 20 levels. Each level object configures obstacles (`gaps`, `balls`, `planes`), teacher behavior (`wakeChance`, `patrol`), and recess mechanics (`recess`).
+- **Game state** (lines 236–254): `game` object holds global state (level, keys, recess); `boy` and `teacher` are the two main entity objects.
+- **Input handling** (lines 275–311): Unified `press(act, on)` function maps both touch events (`.btn` elements) and keyboard events to game actions.
+- **Game loop** (lines 421–538): `update()` runs physics and AI; `render()` (lines 542–867) draws everything imperatively on a `<canvas>` element via the 2D context.
+- **Audio** (lines 349–362): Web Audio API oscillators synthesize all sound effects inline — no audio files.
+
+## Key Conventions
+
+- The canvas is fixed at 800×420 logical pixels; CSS scales it to fit the viewport.
+- `GROUND = H - 60` (360px) is the shared floor y-coordinate used by all entities.
+- Level definitions in `LEVELS` are treated as read-only at runtime — `loadLevel()` always copies obstacle arrays (`balls`, `planes`) before mutating them.
+- Teacher modes: `'seated'` (sleeps, may wake), `'patrol'` (walks back and forth with a sight cone), `'chase'` (pursues the player after recess bell).


### PR DESCRIPTION
## Summary

Added `CLAUDE.md` to provide guidance for Claude Code when working with this repository. This documentation file serves as a reference for understanding the project structure, architecture, and key conventions.

## Changes

- **New file: `CLAUDE.md`** — Comprehensive guide covering:
  - Project overview identifying this as a 20-level 2D platformer called "El Rescate de Manchitas"
  - Instructions for running the single-file HTML game directly in a browser
  - Detailed architecture breakdown mapping code sections to their line ranges and purposes:
    - CSS styling (lines 7–107)
    - Game constants and level definitions (lines 199–230)
    - Game state management (lines 236–254)
    - Input handling system (lines 275–311)
    - Game loop with physics and rendering (lines 421–867)
    - Web Audio API sound synthesis (lines 349–362)
  - Key conventions and implementation details:
    - Fixed 800×420 canvas resolution
    - Ground y-coordinate constant (`GROUND = H - 60`)
    - Level data immutability patterns
    - Teacher AI modes (`'seated'`, `'patrol'`, `'chase'`)

## Purpose

This documentation enables Claude Code to quickly understand the codebase structure and conventions, facilitating more effective AI-assisted development and maintenance of the game.

https://claude.ai/code/session_01CJEayEBaJEB3KVT7Mm1Jdw